### PR TITLE
Users can now choose which SPI peripheral to use

### DIFF
--- a/src/ShiftRegister74HC595.h
+++ b/src/ShiftRegister74HC595.h
@@ -20,7 +20,7 @@ public:
 #if !defined(SHIFT_REGISTER_USES_SPI_WITH_FREQUENCY)
     ShiftRegister74HC595(const uint8_t serialDataPin, const uint8_t clockPin, const uint8_t latchPin);
 #else
-    ShiftRegister74HC595(const uint8_t latchPin, SPIClass* SPIPeripheral = SPI);
+    ShiftRegister74HC595(const uint8_t latchPin, SPIClass* SPIPeripheral = &SPI);
 #endif
     
     void setAll(const uint8_t * digitalValues);

--- a/src/ShiftRegister74HC595.h
+++ b/src/ShiftRegister74HC595.h
@@ -20,7 +20,7 @@ public:
 #if !defined(SHIFT_REGISTER_USES_SPI_WITH_FREQUENCY)
     ShiftRegister74HC595(const uint8_t serialDataPin, const uint8_t clockPin, const uint8_t latchPin);
 #else
-    ShiftRegister74HC595(const uint8_t latchPin);
+    ShiftRegister74HC595(const uint8_t latchPin, SPIClass* SPIPeripheral = SPI);
 #endif
     
     void setAll(const uint8_t * digitalValues);
@@ -37,6 +37,10 @@ public:
     void order(uint8_t o);
 
 private:
+    #ifdef SHIFT_REGISTER_USES_SPI_WITH_FREQUENCY
+    SPIClass* _SPIPeripheral;
+    #endif
+
     #ifdef __AVR__
     uint8_t bo = MSBFIRST;
     #else

--- a/src/ShiftRegister74HC595.hpp
+++ b/src/ShiftRegister74HC595.hpp
@@ -41,9 +41,10 @@ ShiftRegister74HC595<Size>::ShiftRegister74HC595(const uint8_t serialDataPin, co
 // ShiftRegister74HC595 constructor
 // Size is the number of shiftregisters stacked in serial
 template<uint8_t Size>
-ShiftRegister74HC595<Size>::ShiftRegister74HC595(const uint8_t latchPin)
+ShiftRegister74HC595<Size>::ShiftRegister74HC595(const uint8_t latchPin,SPIClass* SPIPeripheral)
 { 
     _latchPin = latchPin;
+    _SPIPeripheral = SPIPeripheral;
 
 #ifdef __AVR__
     _pinMask = digitalPinToBitMask(latchPin);
@@ -61,8 +62,8 @@ ShiftRegister74HC595<Size>::ShiftRegister74HC595(const uint8_t latchPin)
     // allocates the specified number of bytes and initializes them to zero
     memset(_digitalValues, 0, Size * sizeof(uint8_t));
 
-    SPI.begin();
-    SPI.beginTransaction(SPISettings(SHIFT_REGISTER_USES_SPI_WITH_FREQUENCY, bo, SPI_MODE0));
+    _SPIPeripheral->begin();
+    _SPIPeripheral->beginTransaction(SPISettings(SHIFT_REGISTER_USES_SPI_WITH_FREQUENCY, bo, SPI_MODE0));
 
     updateRegisters();       // reset shift register
 }
@@ -131,7 +132,7 @@ template<uint8_t Size>
 void ShiftRegister74HC595<Size>::updateRegisters()
 {
     for (int i = Size - 1; i >= 0; i--) {
-        SPI.transfer(_digitalValues[i]);
+        _SPIPeripheral->transfer(_digitalValues[i]);
     }
     #ifdef __AVR__
     *_port |= _pinMask;


### PR DESCRIPTION
The constructor can now accept a pointer to an SPIClass to specify which SPI peripheral to use. A private member variable has been added to store said pointer.
This is useful when using the library with MCUs having multiple SPI interfaces